### PR TITLE
ci: try fix generate documentation

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -30,10 +30,10 @@ jobs:
           swift package resolve;
           xcodebuild docbuild -scheme fs-app-health-checks -derivedDataPath /tmp/docbuild -destination 'generic/platform=iOS';
           $(xcrun --find docc) process-archive \
-            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/AppHealthChecks.doccarchive \
+            transform-for-static-hosting /tmp/docbuild/Build/Products/Debug-iphoneos/HealthChecks.doccarchive \
             --output-path docs \
-            --hosting-base-path apphealthchecks;
-          echo "<script>window.location.href += \"/documentation/apphealthchecks\"</script>" > docs/index.html;
+            --hosting-base-path healthchecks;
+          echo "<script>window.location.href += \"/documentation/healthchecks\"</script>" > docs/index.html;
 
       - name: Upload artifact 📜
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Enable to generate swift documentation
It merge for fix - https://github.com/LLCFreedom-Space/fs-app-health-checks/issues/17
Change docc.yml
