### PR TITLE
refactor: refactor mongo connection

### DIFF
--- a/Sources/HealthChecks/Extensions/Application+Extensions.swift
+++ b/Sources/HealthChecks/Extensions/Application+Extensions.swift
@@ -234,8 +234,14 @@ extension Application {
     }
 
     /// Variable for `MongoDatabase`
-    public var mongoCluster: MongoCluster? {
+    public var healthCheckMongoCluster: MongoCluster? {
         get { storage[MongoClusterKey.self] }
         set { storage[MongoClusterKey.self] = newValue }
+    }
+
+    /// Initialize MongoDB
+    /// - Parameter connectionString: URI as `String`. Example: "mongodb://localhost/myapp
+    public func initializeHealthCheckMongoCluster(connectionString: String) async throws {
+        self.healthCheckMongoCluster = try await MongoCluster(connectingTo: ConnectionSettings(connectionString))
     }
 }

--- a/Sources/HealthChecks/MongoHealthChecks/MongoRequest.swift
+++ b/Sources/HealthChecks/MongoHealthChecks/MongoRequest.swift
@@ -41,10 +41,10 @@ public struct MongoRequest: MongoRequestSendable {
     /// - Parameter url: `String`
     /// - Returns: `String`
     public func getConnection(by url: String) async throws -> String {
-        await app.mongoCluster?.disconnect()
-        app.mongoCluster = try? MongoCluster(lazyConnectingTo: ConnectionSettings(url))
-        let connection = "\(app.mongoCluster?.connectionState ?? .disconnected)"
-        await app.mongoCluster?.disconnect()
-        return connection
+        let connectionState = "\(app.healthCheckMongoCluster?.connectionState ?? .disconnected)"
+        if connectionState.contains("disconnected") {
+            app.logger.error("ERROR: MongoCluster not connection")
+        }
+        return connectionState
     }
 }


### PR DESCRIPTION
Fix mongo connection for check mongo status
Fix create new connection to mongo every time when check mongo connection
Add init for mongo cluster and save it in application storage
Change check connection for mongoDB. Save mongoCluster in application storage and then get from storage
